### PR TITLE
Add support for newest QMK version

### DIFF
--- a/keyboards/ardux/thepaintbrush/config.h
+++ b/keyboards/ardux/thepaintbrush/config.h
@@ -8,9 +8,9 @@
 #define VENDOR_ID       0x7E71
 #define PRODUCT_ID      0x7E72
 #define DEVICE_VER      0x0001
-#define MANUFACTURER    ardux
-#define PRODUCT         thepaintbrush
-#define DESCRIPTION     thepaintbrush
+#define MANUFACTURER    "ardux"
+#define PRODUCT         "thepaintbrush"
+#define DESCRIPTION     "thepaintbrush"
 
 /* Board layout */
 #define MATRIX_ROWS 2

--- a/keyboards/ardux/thepaintbrush/rules.mk
+++ b/keyboards/ardux/thepaintbrush/rules.mk
@@ -11,6 +11,16 @@ TERMINAL_ENABLE = no
 VIA_ENABLE = no
 LTO_ENABLE = no # We support arm qmk devices which are incompatabl with this avr specific option
 
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   ATmega32A    bootloadHID
+#   ATmega328P   USBasp
+BOOTLOADER = caterina # New QMK versions seem to require this. For now we specify the bootloader here.
+
 # Work around limitation with userland and the way we have 'dynamic' direct wiring
 #     This *should* live in config.h but KemoNine can't figure out how to check which keymap is in use at that level
 PINS_HAND_LEFT = -DDIRECT_PINS="{ { F7, F6, F5, F4 }, { B6, B2, B3, B1 } }"


### PR DESCRIPTION
Added BOOTLOADER to thepainthbrush and quoted the USB descriptors.

NOTE:  I don't know if people are expected to choose their own bootloaders when using The Paintbrush.