### PR TITLE
Remove microdox from github build due to qmk updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,14 +80,14 @@ jobs:
             hand: right
             size: big
             fwext: hex
-          - layout: boardsource_microdox
-            hand: left
-            size: big
-            fwext: hex
-          - layout: boardsource_microdox
-            hand: right
-            size: big
-            fwext: hex
+          # - layout: boardsource_microdox
+          #   hand: left
+          #   size: big
+          #   fwext: hex
+          # - layout: boardsource_microdox
+          #   hand: right
+          #   size: big
+          #   fwext: hex
           - layout: splitkb_kyria_rev2
             hand: right
             size: big


### PR DESCRIPTION
The Microdox definition in the main QMK repo isn't working, and I would like to remove it from our build pipeline until it is requested to be added back in.