### PR TITLE
qmk code update build step fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,8 +181,7 @@ jobs:
         run: |
             if [ -d /qmk_firmware/.git ]; 
             then 
-                cd /qmk_firmware;
-                git pull; 
+                echo "ignoring qmk updates as we are on a disconnected head"
             else 
                 git clone --branch 0.18.5 https://github.com/qmk/qmk_firmware.git /qmk_firmware/; 
             fi


### PR DESCRIPTION
this fixes the build step 'update qmk sources' so it will no longer throw an error ; the problem is due to the use of a static qmk version and 'git pull' / 'git update' not working with detached heads