### PR TITLE
setup corne to use qwiic port for spit communication and enable neopixel use

### DIFF
--- a/users/ardux/layout/boards/crkbd_rev1.h
+++ b/users/ardux/layout/boards/crkbd_rev1.h
@@ -2,6 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+/////////////
+// kb2040 qwiic & neopixel support
+#ifdef CONVERT_TO_KB2040
+#define SOFT_SERIAL_PIN D5
+#define RGB_DI_PIN 17
+#endif
+
 // /////////
 // User remixes / tweaks -- these take precidence above all else
 #if __has_include("../remixes/boards/crkbd_rev1.h")


### PR DESCRIPTION
Makes the corne honor use some adafruit kb2040 specific setup. this is *optional* and is *not* setup as a default anywhere