### PR TITLE
basic, layer based underglow support for arm boards

### DIFF
--- a/users/ardux/config.h
+++ b/users/ardux/config.h
@@ -4,8 +4,12 @@
 #pragma once
 
 // //////////
-// RGB 'stuff' is unsupported
+// RGB 'stuff' is generally unsupported
 #undef RGBLIGHT_ANIMATIONS
+#ifdef ARDUX_LAYER_UNDERGLOW
+#define RGBLIGHT_LAYERS
+#define RGBLIGHT_MAX_LAYERS 32
+#endif
 
 // //////////
 // Combos Config

--- a/users/ardux/rules.mk
+++ b/users/ardux/rules.mk
@@ -14,7 +14,15 @@ TERMINAL_ENABLE = no
 VIA_ENABLE = no
 WPM_ENABLE = no
 ENCODER_ENABLE = no
-RGBLIGHT_ENABLE = no
+
+###########
+# RGB layer underglow
+ifeq ($(ARDUX_LAYER_UNDERGLOW), yes)
+	RGBLIGHT_ENABLE = yes
+	OPT_DEFS += -DARDUX_LAYER_UNDERGLOW
+else
+	RGBLIGHT_ENABLE = no
+endif
 
 ##########
 # Enable LTO if possible (graphics on avr mainly)


### PR DESCRIPTION
- allows underglow/neopixel indicators (useful for non-oled builds)
-use `-e ARDUX_LAYER_UNDERGLOW=yes` to enable during build
- off by default
- tested with corne and kb2040

current color scheme:
- big: blue
- 40p: cyan
- misc (temp layers): purple
- toggle keys (shift lock, caps, etc): orange
- toggle layers (mouse, nav, etc): red